### PR TITLE
Add --scheduler_hints to share replica create command

### DIFF
--- a/manilaclient/osc/v2/share_replicas.py
+++ b/manilaclient/osc/v2/share_replicas.py
@@ -11,6 +11,7 @@
 #   under the License.
 import logging
 
+from osc_lib.cli import parseractions
 from osc_lib.command import command
 from osc_lib import exceptions
 from osc_lib import utils as osc_utils
@@ -44,6 +45,15 @@ class CreateShareReplica(command.ShowOne):
             default=False,
             help=_('Wait for replica creation')
         )
+        parser.add_argument(
+            "--scheduler-hint",
+            metavar="<key=value>",
+            default={},
+            action=parseractions.KeyValueAction,
+            help=_("Scheduler hints for the share replica as key=value pairs, "
+                   "Supported key is only_host."
+                   "(repeat option to set multiple hints)"),
+        )
         return parser
 
     def take_action(self, parsed_args):
@@ -51,9 +61,15 @@ class CreateShareReplica(command.ShowOne):
 
         share = osc_utils.find_resource(share_client.shares,
                                         parsed_args.share)
+        scheduler_hints = {}
+        if parsed_args.scheduler_hint:
+            scheduler_hints = utils.extract_key_value_options(
+                parsed_args.scheduler_hint)
+
         share_replica = share_client.share_replicas.create(
             share,
-            availability_zone=parsed_args.availability_zone
+            availability_zone=parsed_args.availability_zone,
+            scheduler_hints=scheduler_hints
         )
         if parsed_args.wait:
             if not osc_utils.wait_for_status(

--- a/manilaclient/tests/unit/osc/v2/test_share_replicas.py
+++ b/manilaclient/tests/unit/osc/v2/test_share_replicas.py
@@ -78,7 +78,8 @@ class TestShareReplicaCreate(TestShareReplica):
 
         self.replicas_mock.create.assert_called_with(
             self.share,
-            availability_zone=None
+            availability_zone=None,
+            scheduler_hints={}
         )
 
         self.assertCountEqual(self.columns, columns)
@@ -100,7 +101,8 @@ class TestShareReplicaCreate(TestShareReplica):
 
         self.replicas_mock.create.assert_called_with(
             self.share,
-            availability_zone=self.share.availability_zone
+            availability_zone=self.share.availability_zone,
+            scheduler_hints={}
         )
 
         self.assertCountEqual(self.columns, columns)
@@ -122,7 +124,8 @@ class TestShareReplicaCreate(TestShareReplica):
 
         self.replicas_mock.create.assert_called_with(
             self.share,
-            availability_zone=None
+            availability_zone=None,
+            scheduler_hints={}
         )
 
         self.replicas_mock.get.assert_called_with(self.share_replica.id)
@@ -147,7 +150,8 @@ class TestShareReplicaCreate(TestShareReplica):
 
             self.replicas_mock.create.assert_called_with(
                 self.share,
-                availability_zone=None
+                availability_zone=None,
+                scheduler_hints={}
             )
 
             mock_logger.error.assert_called_with(

--- a/manilaclient/tests/unit/v2/test_share_replicas.py
+++ b/manilaclient/tests/unit/v2/test_share_replicas.py
@@ -41,6 +41,7 @@ class ShareReplicasTest(utils.TestCase):
         values = {
             'availability_zone': 'az1',
             'share': 's1',
+            'scheduler_hints': None,
         }
         self._create_common(values)
 

--- a/manilaclient/v2/share_replicas.py
+++ b/manilaclient/v2/share_replicas.py
@@ -112,16 +112,19 @@ class ShareReplicaManager(base.ManagerWithFind):
 
     @api_versions.wraps("2.11", constants.REPLICA_PRE_GRADUATION_VERSION)
     @api_versions.experimental_api
-    def create(self, share, availability_zone=None):
+    def create(self, share, availability_zone=None, scheduler_hints=None):
         return self._create_share_replica(
-            share, availability_zone=availability_zone)
+            share, availability_zone=availability_zone,
+            scheduler_hints=None)
 
     @api_versions.wraps(constants.REPLICA_GRADUATION_VERSION)  # noqa
-    def create(self, share, availability_zone=None):  # noqa F811
+    def create(self, share, availability_zone=None, scheduler_hints=None):  # pylint: disable=function-redefined  # noqa F811
         return self._create_share_replica(
-            share, availability_zone=availability_zone)
+            share, availability_zone=availability_zone,
+            scheduler_hints=scheduler_hints)
 
-    def _create_share_replica(self, share, availability_zone=None):
+    def _create_share_replica(self, share, availability_zone=None,
+                              scheduler_hints=None):
         """Create a replica for a share.
 
         :param share: The share to create the replica of. Can be the share
@@ -135,6 +138,7 @@ class ShareReplicaManager(base.ManagerWithFind):
         if availability_zone:
             body['availability_zone'] = common_base.getid(availability_zone)
 
+        body['scheduler_hints'] = scheduler_hints
         return self._create(RESOURCES_PATH,
                             {RESOURCE_NAME: body},
                             RESOURCE_NAME)

--- a/manilaclient/v2/shell.py
+++ b/manilaclient/v2/shell.py
@@ -5993,12 +5993,26 @@ def do_share_replica_list(cs, args):
     action='single_alias',
     metavar='<availability-zone>',
     help='Optional Availability zone in which replica should be created.')
+@cliutils.arg(
+    '--scheduler-hints',
+    '--scheduler_hints',
+    '--sh',
+    metavar='<key=value>',
+    nargs='*',
+    help='Scheduler hints for the share replica as key=value pairs, '
+         'Supported key is only_host.',
+    default=None)
 @api_versions.wraps("2.11")
 def do_share_replica_create(cs, args):
     """Create a share replica."""
     share = _find_share(cs, args.share)
 
-    replica = cs.share_replicas.create(share, args.availability_zone)
+    scheduler_hints = {}
+    if args.scheduler_hints:
+        scheduler_hints = _extract_key_value_options(args, 'scheduler_hints')
+
+    replica = cs.share_replicas.create(share, args.availability_zone,
+                                       scheduler_hints=scheduler_hints)
     _print_share_replica(cs, replica)
 
 


### PR DESCRIPTION
This commit adds --scheduler_hints option to share replica create command.
Users can specify scheduler hints e.g. "only_host=host@backend#pool" to
share replica create command which will then force share replica creation
on the specified host.