### PR TITLE
Add option to override API endpoint (#5)

### DIFF
--- a/manilaclient/osc/plugin.py
+++ b/manilaclient/osc/plugin.py
@@ -113,4 +113,17 @@ def build_option_parser(parser):
              'version supported by both the client and the server). '
              '(Env: OS_SHARE_API_VERSION)',
     )
+    parser.add_argument(
+        "--os-shared-file-system-endpoint-override",
+        metavar="<shared-file-system-endpoint-override>",
+        default=utils.env(
+            "OS_SHARED_FILE_SYSTEM_ENDPOINT_OVERRIDE",
+            "OS_MANILA_BYPASS_URL",
+            "MANILACLIENT_BYPASS_URL",
+        ),
+        help=(
+            "Use this API endpoint instead of the Service Catalog. "
+            "Defaults to env[OS_SHARED_FILE_SYSTEM_ENDPOINT_OVERRIDE]."
+        ),
+    )
     return parser


### PR DESCRIPTION
Usage: "openstack --os-shared-file-system-endpoint-override https://.../v1 share list"
(cherry picked from commit e0323e69940b1a06edf8c6f96313fff81302299f)